### PR TITLE
max 25 devices on arraylist

### DIFF
--- a/BtSendData/app/src/main/java/com/example/myapplication/StartConnection.java
+++ b/BtSendData/app/src/main/java/com/example/myapplication/StartConnection.java
@@ -110,6 +110,7 @@ public class StartConnection extends AppCompatActivity implements AdapterView.On
     private BroadcastReceiver mBroadcastReceiver3 = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
+            if(mBTDevices.size()<25 ) {
             final String action = intent.getAction();
             Log.d(TAG, "onReceive: ACTION FOUND.");
 
@@ -122,7 +123,7 @@ public class StartConnection extends AppCompatActivity implements AdapterView.On
                 lvNewDevices.setAdapter(mDeviceListAdapter);
 
             }
-        }
+        }}
     };
 
     /**


### PR DESCRIPTION
## Description
fixed a bug which displays every single bluetooth device in the universe, maximum is now set to 25 devices
## Related issue(s)
#40 